### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 3.0 og oppretter catalog-info.yaml

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,5 @@
-version: 1.0
-organisasjon: Eiendom
+version: 3.0
+organization: Eiendom
+product: Grunnbok
+repo_types: [Documentation]
+platforms: [LOKALT]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,1 @@
+Jwt is not in the form of Header.Payload.Signature with two dots and 3 sections


### PR DESCRIPTION
Denne PRen oppdaterer `.sikkerhet/beskrivelse.yaml` til versjon 3.0. Det innebærer at feltene nå blir på engelsk i stedet for norsk. Følgende felter legges inn:

- `version: 3.0`
- `organization: Eiendom`
- `product: Grunnbok`
- `repo_types: [Documentation]`
- `platforms: [LOKALT]`

Videre oppdaterer denne PRen `catalog-info.yaml` for å gi entiteter til Backstage.

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.