### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,4 @@
 
 * @kartverket/digibok
 
-/.sikkerhet/ @haakl
+/.security/ @haakl

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Eiendom
 product: Grunnbok
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "digibok"
   system: "grunnbok"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_eksempelklient-etinglysing-altinn"
-  title: "Security Champion eksempelklient-etinglysing-altinn"
-spec:
-  type: "security_champion"
-  parent: "eiendom_security_champions"
-  members:
-  - "haakl"
-  children:
-  - "resource:eksempelklient-etinglysing-altinn"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "eksempelklient-etinglysing-altinn"
-  links:
-  - url: "https://github.com/kartverket/eksempelklient-etinglysing-altinn"
-    title: "eksempelklient-etinglysing-altinn på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_eksempelklient-etinglysing-altinn"
-  dependencyOf:
-  - "component:eksempelklient-etinglysing-altinn"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml